### PR TITLE
Don't default namespace in client

### DIFF
--- a/pkg/router/client.go
+++ b/pkg/router/client.go
@@ -105,17 +105,12 @@ func (s *statusClient) Patch(ctx context.Context, obj kclient.Object, patch kcli
 }
 
 type reader struct {
-	scheme           *runtime.Scheme
-	client           kclient.Client
-	defaultNamespace string
-	registry         TriggerRegistry
+	scheme   *runtime.Scheme
+	client   kclient.Client
+	registry TriggerRegistry
 }
 
 func (a *reader) Get(ctx context.Context, key kclient.ObjectKey, obj kclient.Object) error {
-	if key.Namespace == "" {
-		key.Namespace = a.defaultNamespace
-	}
-
 	if err := a.registry.Watch(obj, key.Namespace, key.Name, nil); err != nil {
 		return err
 	}
@@ -127,10 +122,6 @@ func (a *reader) List(ctx context.Context, list kclient.ObjectList, opts ...kcli
 	listOpt := &kclient.ListOptions{}
 	for _, opt := range opts {
 		opt.ApplyToList(listOpt)
-	}
-
-	if listOpt.Namespace == "" {
-		listOpt.Namespace = a.defaultNamespace
 	}
 
 	if err := a.registry.Watch(list, listOpt.Namespace, "", listOpt.LabelSelector); err != nil {

--- a/pkg/router/handler.go
+++ b/pkg/router/handler.go
@@ -123,10 +123,9 @@ func (m *HandlerSet) newRequestResponse(gvk schema.GroupVersionKind, key string,
 		FromTrigger: trigger,
 		Client: &client{
 			reader: reader{
-				scheme:           m.scheme,
-				client:           m.backend,
-				defaultNamespace: ns,
-				registry:         triggerRegistry,
+				scheme:   m.scheme,
+				client:   m.backend,
+				registry: triggerRegistry,
 			},
 			writer: writer{
 				client:   m.backend,


### PR DESCRIPTION
This was preventing us from properly retrieving non-namepaced resources,
such as nodes.

addresses https://github.com/acorn-io/baaah/issues/19

Test build of the change:
https://github.com/acorn-io/acorn/pull/272