### PR TITLE
Updates for mink

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "config:base"
-  ]
-}

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/go-logr/logr v1.2.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -317,7 +317,6 @@ go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.5/go.mod h1:5pWMHQbX5EPX2/62yrJeAkowc+lfs/XD7Uxpq3pI6kk=
 go.opencensus.io v0.23.0/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
-go.uber.org/goleak v1.1.12 h1:gZAh5/EyT/HQwlpkCy6wTpqfH9H8Lz8zbm3dZh+OyzA=
 go.uber.org/multierr v1.6.0 h1:y6IPFStTAIT5Ytl7/XYmHvzXQ7S3g/IeZW9hyZ5thw4=
 go.uber.org/zap v1.19.1 h1:ue41HOKd1vGURxrmeKIgELGb3jPW9DMUDGtsinblHwI=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -12,6 +12,7 @@ const (
 )
 
 type Apply interface {
+	Ensure(ctx context.Context, obj ...kclient.Object) error
 	Apply(ctx context.Context, owner kclient.Object, objs ...kclient.Object) error
 	WithOwnerSubContext(ownerSubContext string) Apply
 	WithNamespace(ns string) Apply
@@ -19,6 +20,10 @@ type Apply interface {
 
 	FindOwner(ctx context.Context, obj kclient.Object) (kclient.Object, error)
 	PurgeOrphan(ctx context.Context, obj kclient.Object) error
+}
+
+func Ensure(ctx context.Context, client kclient.Client, obj ...kclient.Object) error {
+	return New(client).Ensure(ctx, obj...)
 }
 
 func New(c kclient.Client) Apply {

--- a/pkg/apply/desiredset.go
+++ b/pkg/apply/desiredset.go
@@ -20,6 +20,14 @@ type apply struct {
 	reconcilers      map[schema.GroupVersionKind]reconciler
 	ownerSubContext  string
 	owner            kclient.Object
+	ensure           bool
+}
+
+func (a apply) Ensure(ctx context.Context, objs ...kclient.Object) error {
+	a.ensure = true
+	a.owner = nil
+	a.ownerSubContext = ""
+	return a.Apply(ctx, nil, objs...)
 }
 
 func (a apply) Apply(ctx context.Context, owner kclient.Object, objs ...kclient.Object) error {

--- a/pkg/apply/desiredset_apply.go
+++ b/pkg/apply/desiredset_apply.go
@@ -145,10 +145,14 @@ func (a *apply) injectLabelsAndAnnotations(in *objectset.ObjectSet, labels, anno
 
 	for _, objMap := range in.ObjectsByGVK() {
 		for _, obj := range objMap {
-			obj = obj.DeepCopyObject().(kclient.Object)
+			if !a.ensure {
+				obj = obj.DeepCopyObject().(kclient.Object)
+			}
 			setLabels(obj, labels)
 			setAnnotations(obj, annotations)
-			result.Add(obj)
+			if err := result.Add(obj); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/pkg/apply/desiredset_crud.go
+++ b/pkg/apply/desiredset_crud.go
@@ -10,10 +10,16 @@ func (a *apply) create(obj kclient.Object) (kclient.Object, error) {
 	return obj, a.client.Create(a.ctx, obj)
 }
 
-func (a *apply) get(gvk schema.GroupVersionKind, namespace, name string) (kclient.Object, error) {
-	ustr := &unstructured.Unstructured{}
-	ustr.SetGroupVersionKind(gvk)
-	return ustr, a.client.Get(a.ctx, kclient.ObjectKey{Namespace: namespace, Name: name}, ustr)
+func (a *apply) get(gvk schema.GroupVersionKind, obj kclient.Object, namespace, name string) (kclient.Object, error) {
+	if obj == nil {
+		ustr := &unstructured.Unstructured{}
+		ustr.SetGroupVersionKind(gvk)
+		obj = ustr
+	} else {
+		obj = obj.DeepCopyObject().(kclient.Object)
+	}
+
+	return obj, a.client.Get(a.ctx, kclient.ObjectKey{Namespace: namespace, Name: name}, obj)
 }
 
 func (a *apply) delete(gvk schema.GroupVersionKind, namespace, name string) error {

--- a/pkg/apply/desiredset_owner.go
+++ b/pkg/apply/desiredset_owner.go
@@ -48,7 +48,7 @@ func (a apply) FindOwner(ctx context.Context, obj kclient.Object) (kclient.Objec
 		return nil, err
 	}
 
-	return a.get(gvk, namespace, name)
+	return a.get(gvk, nil, namespace, name)
 }
 
 func (a apply) PurgeOrphan(ctx context.Context, obj kclient.Object) error {

--- a/pkg/clientaggregator/client.go
+++ b/pkg/clientaggregator/client.go
@@ -1,0 +1,101 @@
+package clientaggregator
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+type Client struct {
+	defaultClient kclient.WithWatch
+	perGroup      map[string]kclient.WithWatch
+	perGroupKind  map[schema.GroupKind]kclient.WithWatch
+}
+
+func New(c kclient.WithWatch) *Client {
+	return &Client{
+		defaultClient: c,
+		perGroup:      map[string]kclient.WithWatch{},
+		perGroupKind:  map[schema.GroupKind]kclient.WithWatch{},
+	}
+}
+
+func (c *Client) AddGroup(group string, client kclient.WithWatch) {
+	c.perGroup[group] = client
+}
+
+func (c *Client) AddGroupKind(groupKind schema.GroupKind, client kclient.WithWatch) {
+	c.perGroupKind[groupKind] = client
+}
+
+func (c *Client) getClient(obj runtime.Object) kclient.WithWatch {
+	gvk, err := apiutil.GVKForObject(obj, c.defaultClient.Scheme())
+	if c, ok := c.perGroup[gvk.Group]; err == nil && ok {
+		return c
+	}
+	if c, ok := c.perGroupKind[gvk.GroupKind()]; err == nil && ok {
+		return c
+	}
+	return c.defaultClient
+}
+
+func (c *Client) Get(ctx context.Context, key kclient.ObjectKey, obj kclient.Object) error {
+	return c.getClient(obj).Get(ctx, key, obj)
+}
+
+func (c *Client) List(ctx context.Context, list kclient.ObjectList, opts ...kclient.ListOption) error {
+	return c.getClient(list).List(ctx, list, opts...)
+}
+
+func (c *Client) Create(ctx context.Context, obj kclient.Object, opts ...kclient.CreateOption) error {
+	return c.getClient(obj).Create(ctx, obj, opts...)
+}
+
+func (c *Client) Delete(ctx context.Context, obj kclient.Object, opts ...kclient.DeleteOption) error {
+	return c.getClient(obj).Delete(ctx, obj, opts...)
+}
+
+func (c *Client) Update(ctx context.Context, obj kclient.Object, opts ...kclient.UpdateOption) error {
+	return c.getClient(obj).Update(ctx, obj, opts...)
+}
+
+func (c *Client) Patch(ctx context.Context, obj kclient.Object, patch kclient.Patch, opts ...kclient.PatchOption) error {
+	return c.getClient(obj).Patch(ctx, obj, patch, opts...)
+}
+
+func (c *Client) DeleteAllOf(ctx context.Context, obj kclient.Object, opts ...kclient.DeleteAllOfOption) error {
+	return c.getClient(obj).DeleteAllOf(ctx, obj, opts...)
+}
+
+func (c *Client) Status() kclient.StatusWriter {
+	return &StatusWriter{c}
+}
+
+func (c *Client) Scheme() *runtime.Scheme {
+	return c.defaultClient.Scheme()
+}
+
+func (c *Client) RESTMapper() meta.RESTMapper {
+	panic("not implemented")
+}
+
+func (c *Client) Watch(ctx context.Context, obj kclient.ObjectList, opts ...kclient.ListOption) (watch.Interface, error) {
+	return c.getClient(obj).Watch(ctx, obj, opts...)
+}
+
+type StatusWriter struct {
+	c *Client
+}
+
+func (s *StatusWriter) Update(ctx context.Context, obj kclient.Object, opts ...kclient.UpdateOption) error {
+	return s.c.getClient(obj).Status().Update(ctx, obj, opts...)
+}
+
+func (s *StatusWriter) Patch(ctx context.Context, obj kclient.Object, patch kclient.Patch, opts ...kclient.PatchOption) error {
+	return s.c.getClient(obj).Status().Patch(ctx, obj, patch, opts...)
+}

--- a/pkg/fields/fields.go
+++ b/pkg/fields/fields.go
@@ -1,0 +1,47 @@
+package fields
+
+import (
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+type Fields interface {
+	fields.Fields
+	FieldNames() []string
+}
+
+func AddFieldConversion(scheme *runtime.Scheme, obj runtime.Object) error {
+	gvk, err := apiutil.GVKForObject(obj, scheme)
+	if err != nil {
+		// ignore errors in determining GVK
+		return nil
+	}
+	f, ok := obj.(Fields)
+	if !ok {
+		return nil
+	}
+	return scheme.AddFieldLabelConversionFunc(gvk, ValidSelectors(f.FieldNames()...))
+}
+
+func AddKnownTypesWithFieldConversion(scheme *runtime.Scheme, gv schema.GroupVersion, types ...runtime.Object) error {
+	for _, obj := range types {
+		scheme.AddKnownTypes(gv, obj)
+		if err := AddFieldConversion(scheme, obj); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ValidSelectors(labels ...string) func(string, string) (string, string, error) {
+	return func(label string, value string) (string, string, error) {
+		for _, checkLabel := range labels {
+			if label == checkLabel {
+				return label, value, nil
+			}
+		}
+		return runtime.DefaultMetaV1FieldSelectorConversion(label, value)
+	}
+}

--- a/pkg/lasso/backend.go
+++ b/pkg/lasso/backend.go
@@ -4,16 +4,20 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/acorn-io/baaah/pkg/backend"
+	"github.com/acorn-io/baaah/pkg/fields"
 	"github.com/acorn-io/baaah/pkg/router"
 	"github.com/acorn-io/baaah/pkg/uncached"
+	controllerruntime "github.com/rancher/lasso/controller-runtime"
 	"github.com/rancher/lasso/pkg/controller"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	kcache "k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
@@ -22,7 +26,7 @@ type Backend struct {
 
 	cacheFactory controller.SharedControllerFactory
 	cache        cache.Cache
-	started      bool
+	started      atomic.Bool
 }
 
 func newBackend(cacheFactory controller.SharedControllerFactory, client *cacheClient, cache cache.Cache) *Backend {
@@ -33,7 +37,12 @@ func newBackend(cacheFactory controller.SharedControllerFactory, client *cacheCl
 	}
 }
 
-func (b *Backend) Start(ctx context.Context) error {
+func (b *Backend) Start(ctx context.Context) (err error) {
+	defer func() {
+		if err == nil {
+			b.started.Store(true)
+		}
+	}()
 	if err := b.cacheFactory.Start(ctx, 5); err != nil {
 		return err
 	}
@@ -67,16 +76,64 @@ func (b *Backend) Trigger(gvk schema.GroupVersionKind, key string, delay time.Du
 	return nil
 }
 
+func (b *Backend) addIndexer(ctx context.Context, gvk schema.GroupVersionKind) error {
+	obj, err := b.Scheme().New(gvk)
+	if err != nil {
+		return err
+	}
+	f, ok := obj.(fields.Fields)
+	if !ok {
+		return nil
+	}
+	caches := b.cacheFactory.SharedCacheFactory().WaitForCacheSync(ctx)
+	if caches[gvk] {
+		return nil
+	}
+
+	cache, err := b.cacheFactory.SharedCacheFactory().ForKind(gvk)
+	if err != nil {
+		return err
+	}
+
+	indexers := map[string]kcache.IndexFunc{}
+	for _, field := range f.FieldNames() {
+		field := field
+		indexers["field:"+field] = kcache.IndexFunc(func(obj interface{}) ([]string, error) {
+			f, ok := obj.(fields.Fields)
+			if !ok {
+				return nil, nil
+			}
+			v := f.Get(field)
+			if v == "" {
+				return nil, nil
+			}
+			vals := []string{controllerruntime.KeyToNamespacedKey("", v)}
+			if ko, ok := obj.(kclient.Object); ok && ko.GetNamespace() != "" {
+				vals = append(vals, controllerruntime.KeyToNamespacedKey(ko.GetNamespace(), v))
+			}
+			return vals, nil
+		})
+	}
+	return cache.AddIndexers(indexers)
+}
+
 func (b *Backend) Watch(ctx context.Context, gvk schema.GroupVersionKind, name string, cb backend.Callback) error {
 	c, err := b.cacheFactory.ForKind(gvk)
 	if err != nil {
+		return err
+	}
+	if err := b.addIndexer(ctx, gvk); err != nil {
 		return err
 	}
 	handler := controller.SharedControllerHandlerFunc(func(key string, obj runtime.Object) (runtime.Object, error) {
 		return cb(gvk, key, obj)
 	})
 	c.RegisterHandler(ctx, fmt.Sprintf("%s %v", name, gvk), handler)
-	return c.Start(ctx, 5)
+
+	if b.started.Load() {
+		return c.Start(ctx, 5)
+	}
+	return nil
 }
 
 func (b *Backend) GVKForObject(obj runtime.Object, scheme *runtime.Scheme) (schema.GroupVersionKind, error) {

--- a/pkg/lasso/clients.go
+++ b/pkg/lasso/clients.go
@@ -21,6 +21,10 @@ type Runtime struct {
 }
 
 func NewRuntime(cfg *rest.Config, scheme *runtime.Scheme) (*Runtime, error) {
+	return NewRuntimeForNamespace(cfg, "", scheme)
+}
+
+func NewRuntimeForNamespace(cfg *rest.Config, namespace string, scheme *runtime.Scheme) (*Runtime, error) {
 	cf, err := lclient.NewSharedClientFactory(cfg, &lclient.SharedClientFactoryOptions{
 		Scheme: scheme,
 	})
@@ -28,7 +32,9 @@ func NewRuntime(cfg *rest.Config, scheme *runtime.Scheme) (*Runtime, error) {
 		return nil, err
 	}
 
-	cacheFactory := lcache.NewSharedCachedFactory(cf, nil)
+	cacheFactory := lcache.NewSharedCachedFactory(cf, &lcache.SharedCacheFactoryOptions{
+		DefaultNamespace: namespace,
+	})
 
 	factory := controller.NewSharedControllerFactory(cacheFactory, &controller.SharedControllerFactoryOptions{
 		DefaultRateLimiter: workqueue.NewItemFastSlowRateLimiter(500*time.Millisecond, time.Second, 2),

--- a/pkg/router/handler.go
+++ b/pkg/router/handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/maps"
 	apierror "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -89,8 +90,8 @@ func (t *triggerRegistry) WatchingGVKs() []schema.GroupVersionKind {
 	return maps.Keys(t.gvks)
 
 }
-func (t *triggerRegistry) Watch(obj runtime.Object, namespace, name string, sel labels.Selector) error {
-	gvk, err := t.trigger.Register(t.gvk, t.key, obj, namespace, name, sel)
+func (t *triggerRegistry) Watch(obj runtime.Object, namespace, name string, sel labels.Selector, fields fields.Selector) error {
+	gvk, err := t.trigger.Register(t.gvk, t.key, obj, namespace, name, sel, fields)
 	if err != nil {
 		return err
 	}
@@ -274,7 +275,7 @@ func (r *response) RetryAfter(delay time.Duration) {
 
 func (r *response) Objects(objs ...kclient.Object) {
 	for _, obj := range objs {
-		r.registry.Watch(obj, obj.GetNamespace(), obj.GetName(), nil)
+		r.registry.Watch(obj, obj.GetNamespace(), obj.GetName(), nil, nil)
 		r.objects = append(r.objects, obj)
 	}
 }

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -102,10 +102,6 @@ func (r *Router) Handle(objType kclient.Object, h Handler) {
 	r.RouteBuilder.Type(objType).Handler(h)
 }
 
-func (r *Router) Middleware(objType kclient.Object, h HandlerFunc) {
-	r.RouteBuilder.Type(objType).Handler(h)
-}
-
 func (r *Router) HandleFunc(objType kclient.Object, h HandlerFunc) {
 	r.RouteBuilder.Type(objType).Handler(h)
 }

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -1,0 +1,201 @@
+package watcher
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/acorn-io/baaah/pkg/typed"
+	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	meta2 "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+var (
+	WatchTimeoutSeconds int64 = 120
+)
+
+type watchFunc func(revision string) (watch.Interface, error)
+
+func doWatch[T client.Object](ctx context.Context, revision string, watchFunc watchFunc, cb func(obj T) (bool, error)) (cont bool, lastRevision string, nonTerminal error, terminal error) {
+	lastRevision = revision
+	result, err := watchFunc(revision)
+	if err != nil {
+		return false, lastRevision, err, nil
+	}
+	defer func() {
+		result.Stop()
+		for range result.ResultChan() {
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return false, lastRevision, nil, fmt.Errorf("terminating watch: %w", ctx.Err())
+		case event, open := <-result.ResultChan():
+			if !open {
+				return false, lastRevision, nil, nil
+			}
+			switch event.Type {
+			case watch.Bookmark:
+				m, err := meta2.Accessor(event.Object)
+				if err == nil && m.GetResourceVersion() != "" {
+					lastRevision = m.GetResourceVersion()
+				}
+			case watch.Deleted:
+				o := event.Object.DeepCopyObject()
+				mo := o.(client.Object)
+				if mo.GetDeletionTimestamp().IsZero() {
+					now := metav1.Now()
+					mo.SetDeletionTimestamp(&now)
+					event.Object = mo
+				}
+				fallthrough
+			case watch.Added, watch.Modified:
+				done, err := cb(event.Object.(T))
+				if apierrors.IsConflict(err) {
+					// if we got a conflict, return a false (not done) and nil for error
+					return false, lastRevision, err, nil
+				}
+				if err != nil {
+					return false, lastRevision, nil, err
+				}
+				if done {
+					return true, lastRevision, nil, nil
+				}
+				m, err := meta2.Accessor(event.Object)
+				if err == nil && m.GetResourceVersion() != "" {
+					lastRevision = m.GetResourceVersion()
+				}
+			case watch.Error:
+				return false, lastRevision, nil, apierrors.FromObject(event.Object)
+			}
+		}
+	}
+}
+
+func retryWatch[T client.Object](ctx context.Context, revision string, watchFunc watchFunc, cb func(obj T) (bool, error)) (T, error) {
+	var last T
+	newCB := func(obj T) (bool, error) {
+		last = obj
+		return cb(obj)
+	}
+	for {
+		o := typed.New[T]()
+		done, lastRevision, err, terminalErr := doWatch(ctx, revision, watchFunc, newCB)
+		if err != nil {
+			logrus.Errorf("error while watching type %T, %T: %v", o, cb, err)
+		} else if terminalErr != nil {
+			logrus.Errorf("terminal error while watching type %T %T: %v", o, cb, terminalErr)
+			return last, terminalErr
+		} else if done {
+			return last, nil
+		}
+		if lastRevision != "" {
+			revision = lastRevision
+		}
+		logrus.Infof("no error, going to restart watch %T, %T from revision %s", o, cb, revision)
+		select {
+		case <-ctx.Done():
+			return last, ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
+type Watcher[T client.Object] struct {
+	client client.WithWatch
+	scheme *runtime.Scheme
+}
+
+func New[T client.Object](client client.WithWatch) *Watcher[T] {
+	return &Watcher[T]{
+		client: client,
+		scheme: client.Scheme(),
+	}
+}
+
+func (w *Watcher[T]) newListObj() (client.ObjectList, error) {
+	obj := typed.New[T]()
+	gvk, err := apiutil.GVKForObject(obj, w.scheme)
+	if err != nil {
+		return nil, err
+	}
+	gvk.Kind += "List"
+	listObj, err := w.scheme.New(gvk)
+	if err != nil {
+		return nil, err
+	}
+	clientListObj, ok := listObj.(client.ObjectList)
+	if !ok {
+		return nil, fmt.Errorf("%T is not a client.ObjectList", listObj)
+	}
+	return clientListObj, nil
+}
+
+func (w *Watcher[T]) ByObject(ctx context.Context, obj T, cb func(obj T) (bool, error)) (def T, _ error) {
+	return w.ByName(ctx, obj.GetNamespace(), obj.GetName(), cb)
+}
+
+func (w *Watcher[T]) ByName(ctx context.Context, namespace, name string, cb func(obj T) (bool, error)) (def T, _ error) {
+	return w.bySelector(ctx, namespace, nil, fields.SelectorFromSet(map[string]string{
+		"metadata.name": name,
+	}), cb)
+}
+
+func (w *Watcher[T]) BySelector(ctx context.Context, namespace string, selector labels.Selector, cb func(obj T) (bool, error)) (def T, _ error) {
+	return w.bySelector(ctx, namespace, selector, nil, cb)
+}
+
+func (w *Watcher[T]) bySelector(ctx context.Context, namespace string, selector labels.Selector, fieldSelector fields.Selector, cb func(obj T) (bool, error)) (def T, _ error) {
+	listObj, err := w.newListObj()
+	if err != nil {
+		return def, err
+	}
+
+	err = w.client.List(ctx, listObj, &client.ListOptions{
+		Namespace:     namespace,
+		LabelSelector: selector,
+		FieldSelector: fieldSelector,
+	})
+	if err != nil {
+		return def, err
+	}
+	rev := listObj.GetResourceVersion()
+
+	var (
+		doneObj T
+		doneSet bool
+	)
+	err = meta2.EachListItem(listObj, func(object runtime.Object) error {
+		done, err := cb(object.(T))
+		if done {
+			doneObj = object.(T)
+			doneSet = true
+		}
+		return err
+	})
+	if doneSet || err != nil {
+		return doneObj, err
+	}
+
+	return retryWatch(ctx, rev, func(revision string) (watch.Interface, error) {
+		return w.client.Watch(ctx, listObj, &client.ListOptions{
+			LabelSelector: selector,
+			FieldSelector: fieldSelector,
+			Namespace:     namespace,
+			Raw: &metav1.ListOptions{
+				ResourceVersion:     revision,
+				AllowWatchBookmarks: true,
+			},
+		})
+	}, cb)
+}

--- a/router.go
+++ b/router.go
@@ -8,6 +8,7 @@ import (
 	"github.com/acorn-io/baaah/pkg/restconfig"
 	"github.com/acorn-io/baaah/pkg/router"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
 )
 
 func DefaultRouter(scheme *runtime.Scheme) (*router.Router, error) {
@@ -16,12 +17,23 @@ func DefaultRouter(scheme *runtime.Scheme) (*router.Router, error) {
 		return nil, err
 	}
 
-	runtime, err := lasso.NewRuntime(cfg, scheme)
+	return NewRouter(DefaultHandlerName(), "", cfg, scheme)
+}
+
+func DefaultHandlerName() string {
+	return filepath.Base(os.Args[0])
+}
+
+func NewRouter(handlerName, namespace string, cfg *rest.Config, scheme *runtime.Scheme) (*router.Router, error) {
+	if handlerName == "" {
+		handlerName = DefaultHandlerName()
+	}
+
+	runtime, err := lasso.NewRuntimeForNamespace(cfg, namespace, scheme)
 	if err != nil {
 		return nil, err
 	}
 
-	name := filepath.Base(os.Args[0])
-	handlerSet := router.NewHandlerSet(name, scheme, runtime.Backend)
+	handlerSet := router.NewHandlerSet(handlerName, scheme, runtime.Backend)
 	return router.New(handlerSet), nil
 }


### PR DESCRIPTION
- Add Ensure to apply for simple Create/Update of resources
- Add indexable fields
- Add client that reads from multiple k8s api servers by apigroup
- Add ability to watch a single namespace
- Add watcher package from acorn
- Support field selectors
- Update go.mod
