### PR TITLE
Add leader election support to the router

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+.vscode/

--- a/pkg/leader/leader.go
+++ b/pkg/leader/leader.go
@@ -1,0 +1,131 @@
+package leader
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+)
+
+const defaultLeaderTTL = 15 * time.Second
+
+type Callback func(context.Context) error
+
+type ElectionConfig struct {
+	TTL                               time.Duration
+	Name, Namespace, ResourceLockType string
+	restCfg                           *rest.Config
+}
+
+func NewDefaultElectionConfig(namespace, name string, cfg *rest.Config) *ElectionConfig {
+	return &ElectionConfig{
+		TTL:              defaultLeaderTTL,
+		Namespace:        namespace,
+		Name:             name,
+		ResourceLockType: resourcelock.LeasesResourceLock,
+		restCfg:          cfg,
+	}
+}
+
+func NewElectionConfig(ttl time.Duration, namespace, name, lockType string, cfg *rest.Config) *ElectionConfig {
+	return &ElectionConfig{
+		TTL:              ttl,
+		Namespace:        namespace,
+		Name:             name,
+		ResourceLockType: lockType,
+		restCfg:          cfg,
+	}
+}
+
+func (ec ElectionConfig) Run(ctx context.Context, cb Callback) error {
+	if ec.Namespace == "" {
+		ec.Namespace = "kube-system"
+	}
+
+	if err := ec.run(ctx, cb); err != nil {
+		return fmt.Errorf("failed to start leader election for %s: %v", ec.Name, err)
+	}
+
+	return nil
+}
+
+func (ec ElectionConfig) run(ctx context.Context, cb Callback) error {
+	id, err := os.Hostname()
+	if err != nil {
+		return err
+	}
+
+	rl, err := resourcelock.NewFromKubeconfig(
+		ec.ResourceLockType,
+		ec.Namespace,
+		ec.Name,
+		resourcelock.ResourceLockConfig{
+			Identity: id,
+		},
+		ec.restCfg,
+		ec.TTL/2,
+	)
+	if err != nil {
+		return fmt.Errorf("error creating leader lock for %s: %v", ec.Name, err)
+	}
+
+	// Catch these signals to ensure a graceful shutdown and leader election release.
+	sigCtx, cancel := signal.NotifyContext(ctx, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGKILL)
+	defer func() {
+		if err != nil {
+			// If we encountered an error, cancel the context because we won't be using it.
+			cancel()
+		}
+	}()
+
+	le, err := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
+		Lock:          rl,
+		LeaseDuration: ec.TTL,
+		RenewDeadline: ec.TTL / 2,
+		RetryPeriod:   ec.TTL / 4,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(ctx context.Context) {
+				if err := cb(ctx); err != nil {
+					logrus.Fatalf("leader callback error: %v", err)
+				}
+			},
+			OnStoppedLeading: func() {
+				select {
+				case <-sigCtx.Done():
+					// The context has been canceled or is otherwise complete.
+					// This is a request to terminate. Exit 0.
+					// Exiting cleanly is useful when the context is canceled
+					// so that Kubernetes doesn't record it exiting in error
+					// when the exit was requested. For example, the wrangler-cli
+					// package sets up a context that cancels when SIGTERM is
+					// sent in. If a node is shut down this is the type of signal
+					// sent. In that case you want the 0 exit code to mark it as
+					// complete so that everything comes back up correctly after
+					// a restart.
+					// The pattern found here can be found inside the kube-scheduler.
+					logrus.Info("requested to terminate, exiting")
+					os.Exit(0)
+				default:
+					logrus.Fatalf("leader election lost for %s", ec.Name)
+				}
+			},
+		},
+		ReleaseOnCancel: true,
+	})
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		le.Run(sigCtx)
+		cancel()
+	}()
+	return nil
+}

--- a/router.go
+++ b/router.go
@@ -1,31 +1,53 @@
 package baaah
 
 import (
+	"github.com/acorn-io/baaah/pkg/backend"
 	"github.com/acorn-io/baaah/pkg/lasso"
+	"github.com/acorn-io/baaah/pkg/leader"
 	"github.com/acorn-io/baaah/pkg/restconfig"
 	"github.com/acorn-io/baaah/pkg/router"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 )
 
-// DefaultRouter The routerName is important as this name will be used to assign ownership of objects
-// created by this router. Specifically the routerName is assigned to the sub-context in the
-// apply actions.
-func DefaultRouter(routerName string, scheme *runtime.Scheme) (*router.Router, error) {
+type Options struct {
+	Backend    backend.Backend
+	RESTConfig *rest.Config
+	Namespace  string
+	// ElectionConfig being nil represents no leader election for the router.
+	ElectionConfig *leader.ElectionConfig
+}
+
+// DefaultOptions represent the standard options for a Router.
+// The default leader election uses a lease lock and a TTL of 15 seconds.
+func DefaultOptions(routerName string, scheme *runtime.Scheme) (*Options, error) {
 	cfg, err := restconfig.New(scheme)
 	if err != nil {
 		return nil, err
 	}
-
-	return NewRouter(routerName, "", cfg, scheme)
-}
-
-func NewRouter(handlerName, namespace string, cfg *rest.Config, scheme *runtime.Scheme) (*router.Router, error) {
-	runtime, err := lasso.NewRuntimeForNamespace(cfg, namespace, scheme)
+	rt, err := lasso.NewRuntimeForNamespace(cfg, "", scheme)
 	if err != nil {
 		return nil, err
 	}
 
-	handlerSet := router.NewHandlerSet(handlerName, scheme, runtime.Backend)
-	return router.New(handlerSet), nil
+	return &Options{
+		Backend:        rt.Backend,
+		RESTConfig:     cfg,
+		ElectionConfig: leader.NewDefaultElectionConfig("", routerName, cfg),
+	}, nil
+}
+
+// DefaultRouter The routerName is important as this name will be used to assign ownership of objects created by this
+// router. Specifically the routerName is assigned to the sub-context in the apply actions. Additionally, the routerName
+// will be used for the leader election lease lock.
+func DefaultRouter(routerName string, scheme *runtime.Scheme) (*router.Router, error) {
+	opts, err := DefaultOptions(routerName, scheme)
+	if err != nil {
+		return nil, err
+	}
+	return NewRouter(routerName, scheme, opts)
+}
+
+func NewRouter(handlerName string, scheme *runtime.Scheme, opts *Options) (*router.Router, error) {
+	return router.New(router.NewHandlerSet(handlerName, scheme, opts.Backend), opts.ElectionConfig), nil
 }


### PR DESCRIPTION
By default, routers will now be created with leader election. The default router will have a resource lock of a lease with a TTL of 15 seconds. New create functions are added to allow a caller to configure the leader election or disable it completely.