### PR TITLE
Use GitHub runners for workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,13 +1,13 @@
 name: test
 on:
   push:
-    branchs:
+    branches:
       - main
   pull_request: {}
 
 jobs:
   test:
-    runs-on: buildjet-4vcpu-ubuntu-2004
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
@cjellick asked that this use GitHub runners instead of buildjet.