### PR TITLE
Prevent OOM on context cancel

### DIFF
--- a/pkg/lasso/cached.go
+++ b/pkg/lasso/cached.go
@@ -63,7 +63,7 @@ func (c *cacheClient) startPurge(ctx context.Context) {
 		for {
 			select {
 			case <-ctx.Done():
-				break
+				return
 			case <-time.After(cacheDuration):
 			}
 


### PR DESCRIPTION
When the context is canceled an infinite loop creating goroutines
would happen causing an almost immediate exhaustion of memory.
