### PR TITLE
Ensure we use default loading rules

### DIFF
--- a/pkg/restconfig/restconfig.go
+++ b/pkg/restconfig/restconfig.go
@@ -17,7 +17,8 @@ func Default() (*rest.Config, error) {
 }
 
 func ClientConfigFromFile(file, context string) clientcmd.ClientConfig {
-	loader := &clientcmd.ClientConfigLoadingRules{ExplicitPath: file}
+	loader := clientcmd.NewDefaultClientConfigLoadingRules()
+	loader.ExplicitPath = file
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		loader,
 		&clientcmd.ConfigOverrides{


### PR DESCRIPTION
By using default loading rules KUBECONFIG env will be respected if
it of the format file1:file2:file3

Signed-off-by: Darren Shepherd <darren@acorn.io>
