### PR TITLE
Quote go version to not confuse yaml

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: "1.19"
       - run: make setup-ci-env
       - run: make validate-ci
       - run: make validate


### PR DESCRIPTION
The current version of go is 1.19 and yaml interprets that as a float.
When renovate tries to bump that to 1.20 yaml interprets that as a float,
so we get go 1.2 not 1.20.

Signed-off-by: Darren Shepherd <darren@acorn.io>
