### PR TITLE
update actions/setup-go to v4 and disable cache

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,8 +12,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
+          cache: false
           go-version: "1.19"
       - run: make setup-ci-env
       - run: make validate-ci


### PR DESCRIPTION
updating to setup-go@v4 enables caching by default. This has ran into the issue of the cache size growing every run, so caching is disabled.