### PR TITLE
Make generate name deterministic in unit tests

### DIFF
--- a/pkg/apply/desiredset_process.go
+++ b/pkg/apply/desiredset_process.go
@@ -80,7 +80,7 @@ func (a *apply) assignOwnerReference(gvk schema.GroupVersionKind, objs objectset
 			}
 		}
 
-		if shouldSet && ownerMeta.GetUID() != "" {
+		if shouldSet && ownerMeta.GetUID() != "" && should(v, AnnotationPrune) {
 			v.SetOwnerReferences(append(v.GetOwnerReferences(), metav1.OwnerReference{
 				APIVersion:         ownerGVK.GroupVersion().String(),
 				Kind:               ownerGVK.Kind,

--- a/pkg/merr/error.go
+++ b/pkg/merr/error.go
@@ -10,6 +10,10 @@ func (e Errors) Err() error {
 	return NewErrors(e...)
 }
 
+func (e Errors) Unwrap() []error {
+	return e
+}
+
 func (e Errors) Error() string {
 	buf := &strings.Builder{}
 	for _, err := range e {

--- a/pkg/router/tester/generate.go
+++ b/pkg/router/tester/generate.go
@@ -1,0 +1,24 @@
+package tester
+
+import (
+	"encoding/json"
+	"math/rand"
+)
+
+const (
+	characters  = "bcdfghjklmnpqrstvwxz2456789"
+	tokenLength = 54
+)
+
+func generate(obj any) (string, error) {
+	d, err := json.Marshal(obj)
+	if err != nil {
+		return "", err
+	}
+	r := rand.New(rand.NewSource(int64(len(d))))
+	token := make([]byte, tokenLength)
+	for i := range token {
+		token[i] = characters[r.Int63n(int64(len(characters)))]
+	}
+	return string(token), nil
+}

--- a/pkg/router/tester/types.go
+++ b/pkg/router/tester/types.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/acorn-io/baaah/pkg/randomtoken"
 	"github.com/acorn-io/baaah/pkg/uncached"
 	"github.com/google/uuid"
 	"golang.org/x/exp/maps"
@@ -123,7 +122,7 @@ func (c *Client) List(ctx context.Context, objList kclient.ObjectList, opts ...k
 func (c *Client) Create(ctx context.Context, obj kclient.Object, opts ...kclient.CreateOption) error {
 	obj.SetUID(types.UID(uuid.New().String()))
 	if obj.GetName() == "" && obj.GetGenerateName() != "" {
-		r, err := randomtoken.Generate()
+		r, err := generate(obj)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- Don't set owner reference if the obj should not be pruned
- Support Unwrap in merr
- Make generate name deterministic in unit tests
