### PR TITLE
Add healthz server

### DIFF
--- a/pkg/leader/leader.go
+++ b/pkg/leader/leader.go
@@ -19,7 +19,8 @@ const (
 	devLeaderTTL     = time.Hour
 )
 
-type Callback func(context.Context) error
+type OnLeader func(context.Context) error
+type OnNewLeader func(string)
 
 type ElectionConfig struct {
 	TTL                               time.Duration
@@ -51,24 +52,24 @@ func NewElectionConfig(ttl time.Duration, namespace, name, lockType string, cfg 
 	}
 }
 
-func (ec ElectionConfig) Run(ctx context.Context, cb Callback) error {
+func (ec *ElectionConfig) Run(ctx context.Context, id string, onLeader OnLeader, onSwitchLeader OnNewLeader) error {
+	if ec == nil {
+		// Don't start leader election if there is no config.
+		return onLeader(ctx)
+	}
+
 	if ec.Namespace == "" {
 		ec.Namespace = "kube-system"
 	}
 
-	if err := ec.run(ctx, cb); err != nil {
+	if err := ec.run(ctx, id, onLeader, onSwitchLeader); err != nil {
 		return fmt.Errorf("failed to start leader election for %s: %v", ec.Name, err)
 	}
 
 	return nil
 }
 
-func (ec ElectionConfig) run(ctx context.Context, cb Callback) error {
-	id, err := os.Hostname()
-	if err != nil {
-		return err
-	}
-
+func (ec *ElectionConfig) run(ctx context.Context, id string, cb OnLeader, onSwitchLeader OnNewLeader) error {
 	rl, err := resourcelock.NewFromKubeconfig(
 		ec.ResourceLockType,
 		ec.Namespace,
@@ -103,9 +104,13 @@ func (ec ElectionConfig) run(ctx context.Context, cb Callback) error {
 					log.Fatalf("leader callback error: %v", err)
 				}
 			},
+			OnNewLeader: onSwitchLeader,
 			OnStoppedLeading: func() {
 				select {
 				case <-sigCtx.Done():
+					// Must cancel so that the registered signals are no longer caught.
+					cancel()
+
 					// The context has been canceled or is otherwise complete.
 					// This is a request to terminate. Exit 0.
 					// Exiting cleanly is useful when the context is canceled
@@ -132,7 +137,6 @@ func (ec ElectionConfig) run(ctx context.Context, cb Callback) error {
 
 	go func() {
 		le.Run(sigCtx)
-		cancel()
 	}()
 	return nil
 }

--- a/pkg/router/healthz.go
+++ b/pkg/router/healthz.go
@@ -1,0 +1,90 @@
+package router
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	"github.com/acorn-io/baaah/pkg/log"
+)
+
+var healthz struct {
+	healths map[string]bool
+	started bool
+	lock    *sync.RWMutex
+	port    int
+}
+
+func init() {
+	healthz.lock = &sync.RWMutex{}
+	healthz.healths = make(map[string]bool)
+}
+
+func setPort(port int) {
+	healthz.lock.Lock()
+	defer healthz.lock.Unlock()
+	if healthz.port > 0 {
+		log.Warnf("healthz port cannot be changed")
+		return
+	}
+	healthz.port = port
+}
+
+func setHealthy(name string, healthy bool) {
+	healthz.lock.Lock()
+	defer healthz.lock.Unlock()
+	healthz.healths[name] = healthy
+}
+
+func getHealthy() bool {
+	healthz.lock.RLock()
+	defer healthz.lock.RUnlock()
+	for _, healthy := range healthz.healths {
+		if !healthy {
+			return false
+		}
+	}
+	return true
+}
+
+// startHealthz starts a healthz server on the healthzPort. If the server is already running, then this is a no-op.
+// Similarly, if the healthzPort is <= 0, then this is a no-op.
+func startHealthz(ctx context.Context) {
+	healthz.lock.Lock()
+	defer healthz.lock.Unlock()
+	if healthz.started || healthz.port <= 0 {
+		return
+	}
+	healthz.started = true
+
+	// Catch these signals to ensure a graceful shutdown of the server.
+	sigCtx, cancel := signal.NotifyContext(ctx, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGKILL)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, req *http.Request) {
+		if getHealthy() {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+
+	srv := &http.Server{
+		Addr:    fmt.Sprintf(":%d", healthz.port),
+		Handler: mux,
+	}
+	go func() {
+		<-sigCtx.Done()
+		// Must cancel so that the registered signals are no longer caught.
+		cancel()
+		if err := srv.Shutdown(ctx); err != nil {
+			log.Warnf("error shutting down healthz server: %v", err)
+		}
+	}()
+	go func() {
+		log.Infof("healthz server stopped: %v", srv.ListenAndServe())
+	}()
+}


### PR DESCRIPTION
A healthz server is added here to indicate when the controller is ready. There are a few caveats here to handle multiple routers being started in a single application.

First, only one healthz server is created per application. The healthz server can be configured to check the health of multiple routers, but the first router created will determine to which port the server binds. The default router will have a port of 8888. However, passing a non-positive port to the New function will result in the router not being monitored by the healthz server. This is useful for situations when many routers are started and stopped in a single application. If these types of routers exist in an application, it is best to turn off healthz checks for them.

Related issue: https://github.com/acorn-io/hub/issues/199