### PR TITLE
Remove triggers when objects get deleted

### DIFF
--- a/pkg/router/handler.go
+++ b/pkg/router/handler.go
@@ -280,6 +280,7 @@ func (m *HandlerSet) onChange(gvk schema.GroupVersionKind, key string, runtimeOb
 
 	if runtimeObject == nil {
 		m.forgetBackoff(gvk, key)
+		defer m.triggers.Unregister(gvk, key, ns, name)
 	}
 
 	return m.handle(gvk, key, runtimeObject, fromTrigger)
@@ -313,7 +314,7 @@ func (m *HandlerSet) handle(gvk schema.GroupVersionKind, key string, unmodifiedO
 		}
 	}
 
-	if err := m.triggers.Trigger(req, resp); err != nil {
+	if err := m.triggers.Trigger(req); err != nil {
 		if err := m.handleError(req, resp, err); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The issue here is that when objects get deleted, their triggers do not. This is an memory leak and can obviously lead to issues.

The fix here is that when an object is deleted, remove all the triggers: both as trigger and triggee.