### PR TITLE
Allow a subcontext change if no owner was set previously

### DIFF
--- a/pkg/apply/desiredset_process.go
+++ b/pkg/apply/desiredset_process.go
@@ -278,9 +278,9 @@ func isAllowOwnerTransition(existingObj, newObj kclient.Object) bool {
 	existingAnno := existingObj.GetAnnotations()
 	newAnno := newObj.GetAnnotations()
 	return newAnno[LabelSubContext] != "" &&
-		existingAnno[LabelGVK] == newAnno[LabelGVK] &&
-		existingAnno[LabelNamespace] == newAnno[LabelNamespace] &&
-		existingAnno[LabelName] == newAnno[LabelName] &&
+		(existingAnno[LabelGVK] == "" || existingAnno[LabelGVK] == newAnno[LabelGVK]) &&
+		(existingAnno[LabelNamespace] == "" || existingAnno[LabelNamespace] == newAnno[LabelNamespace]) &&
+		(existingAnno[LabelName] == "" || existingAnno[LabelName] == newAnno[LabelName]) &&
 		validOwnerChange[fmt.Sprintf("%s => %s", existingAnno[LabelSubContext], newAnno[LabelSubContext])]
 
 }


### PR DESCRIPTION
When allowing a subcontext change, the assumption is also that the owner should remain the same. This doesn't really make sense when no owner was set on the object.

After this change, subcontext changes will be allowed if the owner was not previously set.