### PR TITLE
Improve the multi-client implementation

### DIFF
--- a/pkg/runtime/cached.go
+++ b/pkg/runtime/cached.go
@@ -149,6 +149,9 @@ func (c *cacheClient) List(ctx context.Context, list kclient.ObjectList, opts ..
 }
 
 func (c *cacheClient) Create(ctx context.Context, obj kclient.Object, opts ...kclient.CreateOption) error {
+	if u, ok := obj.(*uncached.Holder); ok {
+		return c.uncached.Create(ctx, u.Object, opts...)
+	}
 	err := c.cached.Create(ctx, obj, opts...)
 	if err != nil {
 		return err
@@ -158,6 +161,9 @@ func (c *cacheClient) Create(ctx context.Context, obj kclient.Object, opts ...kc
 }
 
 func (c *cacheClient) Delete(ctx context.Context, obj kclient.Object, opts ...kclient.DeleteOption) error {
+	if u, ok := obj.(*uncached.Holder); ok {
+		return c.uncached.Delete(ctx, u.Object, opts...)
+	}
 	err := c.cached.Delete(ctx, obj, opts...)
 	if err != nil {
 		return err
@@ -167,6 +173,9 @@ func (c *cacheClient) Delete(ctx context.Context, obj kclient.Object, opts ...kc
 }
 
 func (c *cacheClient) Update(ctx context.Context, obj kclient.Object, opts ...kclient.UpdateOption) error {
+	if u, ok := obj.(*uncached.Holder); ok {
+		return c.uncached.Update(ctx, u.Object, opts...)
+	}
 	err := c.cached.Update(ctx, obj, opts...)
 	if err != nil {
 		return err
@@ -176,6 +185,9 @@ func (c *cacheClient) Update(ctx context.Context, obj kclient.Object, opts ...kc
 }
 
 func (c *cacheClient) Patch(ctx context.Context, obj kclient.Object, patch kclient.Patch, opts ...kclient.PatchOption) error {
+	if u, ok := obj.(*uncached.Holder); ok {
+		return c.uncached.Patch(ctx, u.Object, patch, opts...)
+	}
 	err := c.cached.Patch(ctx, obj, patch, opts...)
 	if err != nil {
 		return err


### PR DESCRIPTION
The first iteration of the multi-client had two issues that are fixed in these changes:

1. The name SpecialConfigs was bad and has been renamed to APIGroupConfigs.
2. The scheme that was built out of the various clients wouldn't have worked in certain scenarios. These changes require the caller to pass a scheme that will work.