### PR TITLE
Change rest mapper to lookup by group

### DIFF
--- a/pkg/runtime/multi/restmapper.go
+++ b/pkg/runtime/multi/restmapper.go
@@ -10,63 +10,51 @@ type multiRestMapper struct {
 }
 
 func (m multiRestMapper) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
-	for _, c := range m.clients {
-		if res, err := c.RESTMapper().KindFor(resource); err == nil {
-			return res, nil
-		}
+	c, err := m.getClientForGroup(resource.Group)
+	if err != nil {
+		return schema.GroupVersionKind{}, err
 	}
-
-	return m.defaultClient.RESTMapper().KindFor(resource)
+	return c.RESTMapper().KindFor(resource)
 }
 
 func (m multiRestMapper) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
-	for _, c := range m.clients {
-		if res, err := c.RESTMapper().KindsFor(resource); err == nil {
-			return res, nil
-		}
+	c, err := m.getClientForGroup(resource.Group)
+	if err != nil {
+		return nil, err
 	}
-
-	return m.defaultClient.RESTMapper().KindsFor(resource)
+	return c.RESTMapper().KindsFor(resource)
 }
 
 func (m multiRestMapper) ResourceFor(input schema.GroupVersionResource) (schema.GroupVersionResource, error) {
-	for _, c := range m.clients {
-		if res, err := c.RESTMapper().ResourceFor(input); err == nil {
-			return res, nil
-		}
+	c, err := m.getClientForGroup(input.Group)
+	if err != nil {
+		return schema.GroupVersionResource{}, err
 	}
-
-	return m.defaultClient.RESTMapper().ResourceFor(input)
+	return c.RESTMapper().ResourceFor(input)
 }
 
 func (m multiRestMapper) ResourcesFor(input schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
-	for _, c := range m.clients {
-		if res, err := c.RESTMapper().ResourcesFor(input); err == nil {
-			return res, nil
-		}
+	c, err := m.getClientForGroup(input.Group)
+	if err != nil {
+		return nil, err
 	}
-
-	return m.defaultClient.RESTMapper().ResourcesFor(input)
+	return c.RESTMapper().ResourcesFor(input)
 }
 
 func (m multiRestMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
-	for _, c := range m.clients {
-		if res, err := c.RESTMapper().RESTMapping(gk, versions...); err == nil {
-			return res, nil
-		}
+	c, err := m.getClientForGroup(gk.Group)
+	if err != nil {
+		return nil, err
 	}
-
-	return m.defaultClient.RESTMapper().RESTMapping(gk, versions...)
+	return c.RESTMapper().RESTMapping(gk, versions...)
 }
 
 func (m multiRestMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
-	for _, c := range m.clients {
-		if res, err := c.RESTMapper().RESTMappings(gk, versions...); err == nil {
-			return res, nil
-		}
+	c, err := m.getClientForGroup(gk.Group)
+	if err != nil {
+		return nil, err
 	}
-
-	return m.defaultClient.RESTMapper().RESTMappings(gk, versions...)
+	return c.RESTMapper().RESTMappings(gk, versions...)
 }
 
 func (m multiRestMapper) ResourceSingularizer(resource string) (string, error) {


### PR DESCRIPTION
Iterating through and ignoring errors has the side effect of causing
the underlying restmapper from controller-runtime to lookup new
discovery information on demand causing a lot of load on the system.

Signed-off-by: Darren Shepherd <darren@acorn.io>
