### PR TITLE
Properly trigger lists of namespaced objects

### DIFF
--- a/pkg/router/matcher.go
+++ b/pkg/router/matcher.go
@@ -69,5 +69,5 @@ func (o *objectMatcher) Match(ns, name string, obj kclient.Object) bool {
 			return o.Fields.Matches(i)
 		}
 	}
-	return o.Namespace == ns
+	return o.Namespace == "" || o.Namespace == ns
 }


### PR DESCRIPTION
If a handler lists all objects across all namespaces, then the trigger on the namespaced objects weren't working because the trigger had an empty namespace, but the object had a non-empty namespace. This change will ensure that these triggers fire correctly.